### PR TITLE
Add auto input switching

### DIFF
--- a/software/sys_controller/ossc/av_controller.h
+++ b/software/sys_controller/ossc/av_controller.h
@@ -61,6 +61,11 @@
 #define FPGA_SCANLINEMODE_V         2
 #define FPGA_SCANLINEMODE_ALT       3
 
+#define AUTO_OFF                    0
+#define AUTO_CURRENT_INPUT          1
+#define AUTO_MAX_COUNT            100
+#define AUTO_CURRENT_MAX_COUNT      6
+
 // In reverse order of importance
 typedef enum {
     NO_CHANGE           = 0,

--- a/software/sys_controller/ossc/controls.c
+++ b/software/sys_controller/ossc/controls.c
@@ -119,6 +119,8 @@ int parse_control()
     alt_u8* pmcfg_ptr[] = { &pt_only, &tc.pm_240p, &tc.pm_384p, &tc.pm_480i, &tc.pm_480p, &tc.pm_480p, &tc.pm_1080i };
     alt_u8 valid_pm[] = { 0x1, 0x1f, 0x3, 0xf, 0x3, 0x3, 0x3 };
 
+    avinput_t next_input = (cm.avinput == AV3_YPBPR) ? AV1_RGBs : (cm.avinput+1);
+
     if (remote_code)
         printf("RCODE: 0x%.4lx, %d\n", remote_code, remote_rpt);
 
@@ -239,6 +241,10 @@ int parse_control()
             lcd_write_status();
             menu_active = 0;
             break;
+        case RC_RIGHT:
+            if (!menu_active)
+                man_target_input = next_input;
+            break;
         default: break;
     }
 
@@ -246,7 +252,7 @@ int parse_control()
 
 Button_Check:
     if (btn_code & PB0_BIT)
-        man_target_input = (cm.avinput == AV3_YPBPR) ? AV1_RGBs : (cm.avinput+1);
+        man_target_input = next_input;
     if (btn_code & PB1_BIT)
         tc.sl_mode = tc.sl_mode < SL_MODE_MAX ? tc.sl_mode + 1 : 0;
 

--- a/software/sys_controller/ossc/menu.c
+++ b/software/sys_controller/ossc/menu.c
@@ -42,6 +42,7 @@ extern alt_u16 tc_h_samplerate, tc_h_synclen, tc_h_bporch, tc_h_active, tc_v_syn
 extern alt_u32 remote_code;
 extern alt_u16 rc_keymap[REMOTE_MAX_KEYS];
 extern alt_u8 vm_sel, profile_sel_menu, lt_sel, def_input, profile_link, lcd_bl_timeout;
+extern alt_u8 auto_input, auto_av1_ypbpr, auto_av2_ypbpr, auto_av3_ypbpr;
 
 alt_u8 menu_active;
 
@@ -66,6 +67,8 @@ static const char *sl_id_desc[] = { LNG("Top","ｳｴ"), LNG("Bottom","ｼﾀ") 
 static const char *audio_dw_sampl_desc[] = { LNG("Off (fs = 96kHz)","ｵﾌ (fs = 96kHz)"), "2x  (fs = 48kHz)" };
 static const char *lt_desc[] = { "Top-left", "Center", "Bottom-right" };
 static const char *lcd_bl_timeout_desc[] = { "Off", "3s", "10s", "30s" };
+static const char *rgsb_ypbpr_desc[] = { "RGsB", "YPbPr" };
+static const char *auto_input_desc[] = { "Off", "Current input", "All inputs" };
 
 static void sampler_phase_disp(alt_u8 v) { sniprintf(menu_row2, LCD_ROW_LEN+1, LNG("%d deg","%d ﾄﾞ"), (v*1125)/100); }
 static void sync_vth_disp(alt_u8 v) { sniprintf(menu_row2, LCD_ROW_LEN+1, "%d mV", (v*1127)/100); }
@@ -181,6 +184,10 @@ MENU(menu_settings, P99_PROTECT({ \
     { LNG("Link input->prof","Link input->prof"),   OPT_AVCONFIG_SELECTION, { .sel = { &profile_link,  OPT_WRAP, SETTING_ITEM(off_on_desc) } } },
     {     "<Import sett.  >",                     OPT_FUNC_CALL,        { .fun = { import_userdata, NULL } } },
     { LNG("Initial input","ｼｮｷﾆｭｳﾘｮｸ"),          OPT_AVCONFIG_SELECTION, { .sel = { &def_input,       OPT_WRAP, SETTING_ITEM(avinput_str) } } },
+    { "Autodetect input",                          OPT_AVCONFIG_SELECTION, { .sel = { &auto_input,     OPT_WRAP, SETTING_ITEM(auto_input_desc) } } },
+    { "Auto AV1 Y/Gs",                          OPT_AVCONFIG_SELECTION, { .sel = { &auto_av1_ypbpr,     OPT_WRAP, SETTING_ITEM(rgsb_ypbpr_desc) } } },
+    { "Auto AV2 Y/Gs",                          OPT_AVCONFIG_SELECTION, { .sel = { &auto_av2_ypbpr,     OPT_WRAP, SETTING_ITEM(rgsb_ypbpr_desc) } } },
+    { "Auto AV3 Y/Gs",                          OPT_AVCONFIG_SELECTION, { .sel = { &auto_av3_ypbpr,     OPT_WRAP, SETTING_ITEM(rgsb_ypbpr_desc) } } },
     { "LCD BL timeout",                         OPT_AVCONFIG_SELECTION, { .sel = { &lcd_bl_timeout,  OPT_WRAP, SETTING_ITEM(lcd_bl_timeout_desc) } } },
     { LNG("<Fw. update    >","<ﾌｧｰﾑｳｪｱｱｯﾌﾟﾃﾞｰﾄ>"), OPT_FUNC_CALL,          { .fun = { fw_update, NULL } } },
 }))

--- a/software/sys_controller/ossc/userdata.c
+++ b/software/sys_controller/ossc/userdata.c
@@ -38,6 +38,7 @@ extern alt_u8 input_profiles[AV_LAST];
 extern alt_u8 profile_sel;
 extern alt_u8 def_input, profile_link;
 extern alt_u8 lcd_bl_timeout;
+extern alt_u8 auto_input, auto_av1_ypbpr, auto_av2_ypbpr, auto_av3_ypbpr;
 extern SD_DEV sdcard_dev;
 extern char menu_row1[LCD_ROW_LEN+1], menu_row2[LCD_ROW_LEN+1];
 
@@ -68,6 +69,10 @@ int write_userdata(alt_u8 entry)
         ((ude_initcfg*)databuf)->def_input = def_input;
         ((ude_initcfg*)databuf)->profile_link = profile_link;
         ((ude_initcfg*)databuf)->lcd_bl_timeout = lcd_bl_timeout;
+        ((ude_initcfg*)databuf)->auto_input = auto_input;
+        ((ude_initcfg*)databuf)->auto_av1_ypbpr = auto_av1_ypbpr;
+        ((ude_initcfg*)databuf)->auto_av2_ypbpr = auto_av2_ypbpr;
+        ((ude_initcfg*)databuf)->auto_av3_ypbpr = auto_av3_ypbpr;
         memcpy(((ude_initcfg*)databuf)->keys, rc_keymap, sizeof(rc_keymap));
         retval = write_flash_page(databuf, sizeof(ude_initcfg), (USERDATA_OFFSET+entry*SECTORSIZE)/PAGESIZE);
         if (retval != 0)
@@ -145,6 +150,10 @@ int read_userdata(alt_u8 entry)
                 target_input = def_input;
             else if (((ude_initcfg*)databuf)->last_input < AV_LAST)
                 target_input = ((ude_initcfg*)databuf)->last_input;
+            auto_input = ((ude_initcfg*)databuf)->auto_input;
+            auto_av1_ypbpr = ((ude_initcfg*)databuf)->auto_av1_ypbpr;
+            auto_av2_ypbpr = ((ude_initcfg*)databuf)->auto_av2_ypbpr;
+            auto_av3_ypbpr = ((ude_initcfg*)databuf)->auto_av3_ypbpr;
             profile_link = ((ude_initcfg*)databuf)->profile_link;
             profile_sel = input_profiles[AV_TESTPAT]; // Global profile
             lcd_bl_timeout = ((ude_initcfg*)databuf)->lcd_bl_timeout;

--- a/software/sys_controller/ossc/userdata.h
+++ b/software/sys_controller/ossc/userdata.h
@@ -53,6 +53,10 @@ typedef struct {
     avinput_t last_input;
     avinput_t def_input;
     alt_u8 lcd_bl_timeout;
+    alt_u8 auto_input;
+    alt_u8 auto_av1_ypbpr;
+    alt_u8 auto_av2_ypbpr;
+    alt_u8 auto_av3_ypbpr;
     alt_u16 keys[REMOTE_MAX_KEYS];
 } __attribute__((packed, __may_alias__)) ude_initcfg;
 


### PR DESCRIPTION
Cycle through inputs until sync is found or limit has been reached.
RGsB or YPbPr defaults can be set per input.
Stay on current physical input for a short time when sync is lost.
Press right button on the remote for next input.