### PR TITLE
Add video Pre-ADC gain setting

### DIFF
--- a/software/sys_controller/ossc/av_controller.c
+++ b/software/sys_controller/ossc/av_controller.c
@@ -339,7 +339,7 @@ status_t get_status(tvp_input_t input, video_format format)
         tvp_set_sync_lpf(tc.sync_lpf);
 
     if (memcmp(&tc.col, &cm.cc.col, sizeof(color_setup_t)))
-        tvp_set_fine_gain_offset(&tc.col);
+        tvp_set_gain_offset(&tc.col);
 
 #ifdef ENABLE_AUDIO
     if ((tc.audio_dw_sampl != cm.cc.audio_dw_sampl) ||

--- a/software/sys_controller/ossc/avconfig.c
+++ b/software/sys_controller/ossc/avconfig.c
@@ -59,6 +59,7 @@ const avconfig_t tc_default = {
         .r_f_off = DEFAULT_FINE_OFFSET,
         .g_f_off = DEFAULT_FINE_OFFSET,
         .b_f_off = DEFAULT_FINE_OFFSET,
+        .c_gain = DEFAULT_COARSE_GAIN,
     },
     .link_av = AV_LAST,
 };

--- a/software/sys_controller/ossc/avconfig.h
+++ b/software/sys_controller/ossc/avconfig.h
@@ -36,6 +36,7 @@
 #define SD_SYNC_WIN_MAX     255
 #define PLL_COAST_MAX       5
 #define REVERSE_LPF_MAX     31
+#define COARSE_GAIN_MAX     15
 
 #define SL_MODE_MAX         2
 #define SL_TYPE_MAX         2

--- a/software/sys_controller/ossc/menu.c
+++ b/software/sys_controller/ossc/menu.c
@@ -80,6 +80,7 @@ static void lt_disp(alt_u8 v) { strncpy(menu_row2, lt_desc[v], LCD_ROW_LEN+1); }
 static void aud_db_disp(alt_u8 v) { sniprintf(menu_row2, LCD_ROW_LEN+1, "%d dB", ((alt_8)v-AUDIO_GAIN_0DB)); }
 static void vm_display_name (alt_u8 v) { strncpy(menu_row2, video_modes[v].name, LCD_ROW_LEN+1); }
 static void link_av_desc (avinput_t v) { strncpy(menu_row2, v == AV_LAST ? "No link" : avinput_str[v], LCD_ROW_LEN+1); }
+static void coarse_gain_disp(alt_u8 v) { sniprintf(menu_row2, LCD_ROW_LEN+1, "%u.%u", ((v*10)+50)/100, (((v*10)+50)%100)/10); }
 
 static const arg_info_t vm_arg_info = {&vm_sel, VIDEO_MODES_CNT-1, vm_display_name};
 static const arg_info_t profile_arg_info = {&profile_sel_menu, MAX_PROFILE, value_disp};
@@ -106,6 +107,7 @@ MENU(menu_vinputproc, P99_PROTECT({ \
     { LNG("R/Pr gain","R/Pr ｹﾞｲﾝ"),             OPT_AVCONFIG_NUMVALUE,  { .num = { &tc.col.r_f_gain,  OPT_NOWRAP, 0, 0xFF, value_disp } } },
     { LNG("G/Y gain","G/Y ｹﾞｲﾝ"),               OPT_AVCONFIG_NUMVALUE,  { .num = { &tc.col.g_f_gain,  OPT_NOWRAP, 0, 0xFF, value_disp } } },
     { LNG("B/Pb gain","B/Pb ｹﾞｲﾝ"),             OPT_AVCONFIG_NUMVALUE,  { .num = { &tc.col.b_f_gain,  OPT_NOWRAP, 0, 0xFF, value_disp } } },
+    { LNG("Pre-ADC Gain","Pre-ADC Gain"),       OPT_AVCONFIG_NUMVALUE,  { .num = { &tc.col.c_gain,    OPT_NOWRAP, 0, COARSE_GAIN_MAX, coarse_gain_disp } } },
 }))
 
 MENU(menu_sampling, P99_PROTECT({ \

--- a/software/sys_controller/tvp7002/tvp7002.c
+++ b/software/sys_controller/tvp7002/tvp7002.c
@@ -151,6 +151,7 @@ void tvp_init()
         .r_f_off = DEFAULT_FINE_OFFSET,
         .g_f_off = DEFAULT_FINE_OFFSET,
         .b_f_off = DEFAULT_FINE_OFFSET,
+        .c_gain = DEFAULT_COARSE_GAIN,
     };
 
     // disable output
@@ -201,20 +202,20 @@ void tvp_init()
     tvp_set_hpllcoast(DEFAULT_PRE_COAST, DEFAULT_POST_COAST);
 
     //set analog (coarse) gain to max recommended value (-> 91% of the ADC range with 0.7Vpp input)
-    tvp_writereg(TVP_BG_CGAIN, 0x88);
-    tvp_writereg(TVP_R_CGAIN, 0x08);
-
     //set rest of the gain digitally (fine) to utilize 100% of the range at the output (0.91*(1+(26/256)) = 1)
-    tvp_set_fine_gain_offset(&def_gain_offs);
+    tvp_set_gain_offset(&def_gain_offs);
 }
 
-void tvp_set_fine_gain_offset(color_setup_t *col) {
+void tvp_set_gain_offset(color_setup_t *col) {
+    tvp_writereg(TVP_BG_CGAIN, ((col->c_gain << 4) | (col->c_gain & 0xF)));
+    tvp_writereg(TVP_R_CGAIN, col->c_gain);
     tvp_writereg(TVP_R_FGAIN, col->r_f_gain);
     tvp_writereg(TVP_G_FGAIN, col->g_f_gain);
     tvp_writereg(TVP_B_FGAIN, col->b_f_gain);
     tvp_writereg(TVP_R_FOFFSET_MSB, col->r_f_off);
     tvp_writereg(TVP_G_FOFFSET_MSB, col->g_f_off);
     tvp_writereg(TVP_B_FOFFSET_MSB, col->b_f_off);
+
 }
 
 // Configure H-PLL (sampling rate, VCO gain and charge pump current)

--- a/software/sys_controller/tvp7002/tvp7002.h
+++ b/software/sys_controller/tvp7002/tvp7002.h
@@ -33,6 +33,7 @@
 #define DEFAULT_SYNC_VTH        0x0B
 #define DEFAULT_FINE_GAIN       26
 #define DEFAULT_FINE_OFFSET     0x80
+#define DEFAULT_COARSE_GAIN     0x8
 
 #define TVP_INTCLK_HZ           6500000UL
 #define TVP_EXTCLK_HZ           27000000UL
@@ -68,6 +69,7 @@ typedef struct {
     alt_u8 r_f_gain;
     alt_u8 g_f_gain;
     alt_u8 b_f_gain;
+    alt_u8 c_gain;
 } __attribute__((packed)) color_setup_t;
 
 
@@ -89,7 +91,7 @@ inline void tvp_set_ssthold(alt_u8 vsdetect_thold);
 
 void tvp_init();
 
-void tvp_set_fine_gain_offset(color_setup_t *col);
+void tvp_set_gain_offset(color_setup_t *col);
 
 void tvp_setup_hpll(alt_u16 h_samplerate, alt_u16 refclks_per_line, alt_u8 plldivby2);
 


### PR DESCRIPTION
The if (memcmp had to be changed back because it was applying the previous value when changing gain settings. It also was not applying the saved gain settings on boot.

The bottom line on Info screen was showing previous menu text if there was no sync.