### PR TITLE
Ignore paths which use shared clock lines.

### DIFF
--- a/ossc.sdc
+++ b/ossc.sdc
@@ -81,6 +81,10 @@ set_false_path -from [get_registers {scanconverter_inst|H_* scanconverter_inst|V
 # Ignore paths from registers which are updated only at leading edge of hsync
 #set_false_path -from [get_registers {scanconverter:scanconverter_inst|line_idx scanconverter:scanconverter_inst|line_out_idx* scanconverter:scanconverter_inst|hmax*}]
 
+# Ignore paths that cross clock domains from 3x to 2x and 5x to 4x, since they share a clock line, but cannot co-occur.
+set_false_path -from [get_clocks {pclk_3x*}] -to [get_registers {scanconverter:scanconverter_inst|*_2x*}]
+set_false_path -from [get_clocks {pclk_5x*}] -to [get_registers {scanconverter:scanconverter_inst|*_4x*}]
+
 # Ignore paths to latency tester sync regs
 set_false_path -to [get_registers {lat_tester:lt0|mode_synced* lat_tester:lt0|VSYNC_in_* lat_tester:lt0|trigger_*}]
 


### PR DESCRIPTION
Quartus calculates fmax (the theoretical maximum clock rate) based on
the entirety of the logic between registers. In the case of the pclk_*
lines, this includes some invalid paths which cross between the
3x <-> 2x and 5x <-> 4x clock domains. This is because these clocks
share output pins from the PLL, but the PLL is configured to output only
one of these clocks at a time, and the correct output from the logic is
selected via a multiplexer. Therefore these paths cannot co-occur.

This has the effect of increasing the calculated fmax of these paths to:

pclk_3x: 107.98 MHz -> 132.52 MHz
pclk_5x: 162.23 MHz -> 170.33 MHz