### PR TITLE
Add 480x272 sampling/optimized mode for the PSP.

### DIFF
--- a/software/sys_controller/ossc/menu.c
+++ b/software/sys_controller/ossc/menu.c
@@ -55,7 +55,7 @@ alt_u8 vm_sel, vm_edit;
 static const char *off_on_desc[] = { LNG("Off","ｵﾌ"), LNG("On","ｵﾝ") };
 static const char *video_lpf_desc[] = { LNG("Auto","ｵｰﾄ"), LNG("Off","ｵﾌ"), "95MHz (HDTV II)", "35MHz (HDTV I)", "16MHz (EDTV)", "9MHz (SDTV)" };
 static const char *ypbpr_cs_desc[] = { "Rec. 601", "Rec. 709", "Auto" };
-static const char *s480p_mode_desc[] = { LNG("Auto","ｵｰﾄ"), "DTV 480p", "VESA 640x480@60" };
+static const char *s480p_mode_desc[] = { LNG("Auto","ｵｰﾄ"), "DTV 480p", "VESA 640x480@60", "PSP 480x272" };
 static const char *s400p_mode_desc[] = { "VGA 640x400@70", "VGA 720x400@70" };
 static const char *sync_lpf_desc[] = { LNG("2.5MHz (max)","2.5MHz (ｻｲﾀﾞｲ)"), LNG("10MHz (med)","10MHz (ﾁｭｳｲ)"), LNG("33MHz (min)","33MHz (ｻｲｼｮｳ)"), LNG("Off","ｵﾌ") };
 static const char *stc_lpf_desc[] = { "4.8MHz (HDTV/PC)", "0.5MHz (SDTV)", "1.7MHz (EDTV)" };

--- a/software/sys_controller/tvp7002/video_modes.c
+++ b/software/sys_controller/tvp7002/video_modes.c
@@ -74,15 +74,39 @@ alt_8 get_mode_id(alt_u32 totlines, alt_u8 progressive, alt_u32 hz, video_type t
             case GROUP_480P:
                 if (video_modes[i].v_total == 525) {
                     if (video_modes[i-1].group == GROUP_480I) { // hit "480p" on the list
-                        if (cm.cc.s480p_mode == 0) // Auto
-                            mode_type &= ~VIDEO_PC;
-                        else if (cm.cc.s480p_mode == 2) // VESA 640x480@60
-                            continue;
+                        switch (cm.cc.s480p_mode) {
+                            case 0: // Auto
+                                mode_type &= ~VIDEO_PC;
+                                break;
+                            case 1: // DTV 480p
+                                break;
+                            case 2: // VESA 640x480@60
+                            case 3: // PSP 480x272
+                                continue;
+                        }
+                    } else if (video_modes[i].flags & MODE_L2_480x272) { // hit "480x272" on the list
+                        switch (cm.cc.s480p_mode) {
+                            case 0: // Auto
+                            case 1: // DTV 480p
+                            case 2: // VESA 640x480@60
+                                continue;
+                            case 3: // PSP 480x272
+                                // force optimized Line2x mode for 480x272
+                                valid_lm[1] = MODE_L2_480x272;
+                                break;
+                        }
                     } else { // "640x480" on the list
-                        if (cm.cc.s480p_mode == 0) // Auto
-                            mode_type &= ~VIDEO_EDTV;
-                        else if (cm.cc.s480p_mode == 1) // DTV 480p
-                            continue;
+                        switch (cm.cc.s480p_mode) {
+                            case 0: // Auto
+                                mode_type &= ~VIDEO_EDTV;
+                                break;
+                            case 1: // DTV 480p
+                                continue;
+                            case 2: // VESA 640x480@60
+                                break;
+                            case 3: // PSP 480x272
+                                continue;
+                        }
                     }
                 } else if (video_modes[i].v_total == 625) { // hit "576p" on the list
                     if ((typemask & VIDEO_PC) && (hz >= 55))
@@ -143,6 +167,7 @@ alt_8 get_mode_id(alt_u32 totlines, alt_u8 progressive, alt_u32 hz, video_type t
                     }
                     break;
                 case MODE_L2_512_COL:
+                case MODE_L2_480x272:
                     cm.fpga_vmultmode = FPGA_V_MULTMODE_2X;
                     cm.fpga_hmultmode = FPGA_H_MULTMODE_OPTIMIZED;
                     cm.sample_mult = 2;

--- a/software/sys_controller/tvp7002/video_modes.h
+++ b/software/sys_controller/tvp7002/video_modes.h
@@ -75,23 +75,24 @@ typedef enum {
     MODE_L2_320_COL     = (1<<6),
     MODE_L2_256_COL     = (1<<7),
     MODE_L2_240x360     = (1<<8),
-    MODE_L3_GEN_16_9    = (1<<9),
-    MODE_L3_GEN_4_3     = (1<<10),
-    MODE_L3_512_COL     = (1<<11),
-    MODE_L3_384_COL     = (1<<12),
-    MODE_L3_320_COL     = (1<<13),
-    MODE_L3_256_COL     = (1<<14),
-    MODE_L3_240x360     = (1<<15),
-    MODE_L4_GEN_4_3     = (1<<16),
-    MODE_L4_512_COL     = (1<<17),
-    MODE_L4_384_COL     = (1<<18),
-    MODE_L4_320_COL     = (1<<19),
-    MODE_L4_256_COL     = (1<<20),
-    MODE_L5_GEN_4_3     = (1<<21),
-    MODE_L5_512_COL     = (1<<22),
-    MODE_L5_384_COL     = (1<<23),
-    MODE_L5_320_COL     = (1<<24),
-    MODE_L5_256_COL     = (1<<25),
+    MODE_L2_480x272     = (1<<9),
+    MODE_L3_GEN_16_9    = (1<<10),
+    MODE_L3_GEN_4_3     = (1<<11),
+    MODE_L3_512_COL     = (1<<12),
+    MODE_L3_384_COL     = (1<<13),
+    MODE_L3_320_COL     = (1<<14),
+    MODE_L3_256_COL     = (1<<15),
+    MODE_L3_240x360     = (1<<16),
+    MODE_L4_GEN_4_3     = (1<<17),
+    MODE_L4_512_COL     = (1<<18),
+    MODE_L4_384_COL     = (1<<19),
+    MODE_L4_320_COL     = (1<<20),
+    MODE_L4_256_COL     = (1<<21),
+    MODE_L5_GEN_4_3     = (1<<22),
+    MODE_L5_512_COL     = (1<<23),
+    MODE_L5_384_COL     = (1<<24),
+    MODE_L5_320_COL     = (1<<25),
+    MODE_L5_256_COL     = (1<<26),
 } mode_flags;
 
 typedef struct {
@@ -148,6 +149,8 @@ typedef struct {
     /* ~525-line modes */ \
     { "480i",      HDMI_480i60,       720,  240,   858, 0, 525,   57, 15,   62, 3,  DEFAULT_SAMPLER_PHASE, (VIDEO_SDTV | VIDEO_PC),   GROUP_480I,     (MODE_PT | MODE_L2 | MODE_L3_GEN_16_9 | MODE_L4_GEN_4_3 | MODE_PLLDIVBY2 | MODE_INTERLACED) },  \
     { "480p",      HDMI_480p60,       720,  480,   858, 0, 525,   60, 30,   62, 6,  DEFAULT_SAMPLER_PHASE, (VIDEO_EDTV | VIDEO_PC),   GROUP_480P,     (MODE_PT | MODE_L2) },                                                                          \
+    /* 480p PSP in-game */ \
+    { "480x272",   HDMI_480p60_16x9,  480,  272,   858, 0, 525,   177,134,  62, 6,  DEFAULT_SAMPLER_PHASE, (VIDEO_EDTV),              GROUP_480P,     (MODE_PT | MODE_L2_480x272) },                                                 \
     { "640x480",   HDMI_640x480p60,   640,  480,   800, 0, 525,   48, 33,   96, 2,  DEFAULT_SAMPLER_PHASE, (VIDEO_PC | VIDEO_EDTV),   GROUP_480P,     (MODE_PT | MODE_L2) },                                                                          \
     /* X68k @ 31kHz */ \
     { "640x512",   HDMI_Unknown,      640,  512,   800, 0, 568,   48, 28,   96, 2,  DEFAULT_SAMPLER_PHASE, (VIDEO_PC | VIDEO_EDTV),   GROUP_480P,     (MODE_PT | MODE_L2) },                                                                          \


### PR DESCRIPTION
This commit adds both a 480p input sampling mode and line2x optimized
mode for the PSP's 480x272 picture. The line2x optimized mode is enabled
automatically when the sampling mode is selected.

When in-game, the PSP outputs a letterboxed 480p picture. The active
portion of the screen is 480x272, but is treated as 480p (480x720).

In addition, a line2x optimized mode is added which produces a 960x544
output picture, which if desired the top + bottom pixels can be dropped
producing a 960x540 (qHD) picture.

To generate a qHD picture, use the following settings:

V. Active: 270
V. Backporch: 135