### PR TITLE
Set only HDMI_TX VREF pins to fast output.

### DIFF
--- a/ossc.qsf
+++ b/ossc.qsf
@@ -240,18 +240,11 @@ set_global_assignment -name SDC_FILE ossc.sdc
 set_global_assignment -name CDF_FILE output_files/Chain1.cdf
 set_global_assignment -name SIGNALTAP_FILE output_files/ossc_la.stp
 set_global_assignment -name QIP_FILE rtl/char_array.qip
-set_instance_assignment -name FAST_OUTPUT_ENABLE_REGISTER ON -to HDMI_TX_DE
-set_instance_assignment -name FAST_OUTPUT_ENABLE_REGISTER ON -to HDMI_TX_HS
-set_instance_assignment -name FAST_OUTPUT_ENABLE_REGISTER ON -to HDMI_TX_PCLK
-set_instance_assignment -name FAST_OUTPUT_ENABLE_REGISTER ON -to HDMI_TX_VS
-set_instance_assignment -name FAST_OUTPUT_ENABLE_REGISTER ON -to HDMI_TX_BD
-set_instance_assignment -name FAST_OUTPUT_ENABLE_REGISTER ON -to HDMI_TX_GD
-set_instance_assignment -name FAST_OUTPUT_ENABLE_REGISTER ON -to HDMI_TX_RD
-set_instance_assignment -name FAST_OUTPUT_REGISTER ON -to HDMI_TX_DE
-set_instance_assignment -name FAST_OUTPUT_REGISTER ON -to HDMI_TX_HS
-set_instance_assignment -name FAST_OUTPUT_REGISTER ON -to HDMI_TX_PCLK
-set_instance_assignment -name FAST_OUTPUT_REGISTER ON -to HDMI_TX_VS
-set_instance_assignment -name FAST_OUTPUT_REGISTER ON -to HDMI_TX_BD
-set_instance_assignment -name FAST_OUTPUT_REGISTER ON -to HDMI_TX_GD
-set_instance_assignment -name FAST_OUTPUT_REGISTER ON -to HDMI_TX_RD
+set_instance_assignment -name FAST_OUTPUT_REGISTER ON -to HDMI_TX_BD[0]
+set_instance_assignment -name FAST_OUTPUT_REGISTER ON -to HDMI_TX_BD[3]
+set_instance_assignment -name FAST_OUTPUT_REGISTER ON -to HDMI_TX_BD[7]
+set_instance_assignment -name FAST_OUTPUT_REGISTER ON -to HDMI_TX_GD[7]
+set_instance_assignment -name FAST_OUTPUT_REGISTER ON -to HDMI_TX_RD[1]
+set_instance_assignment -name FAST_OUTPUT_REGISTER ON -to HDMI_TX_RD[5]
+set_instance_assignment -name FAST_OUTPUT_REGISTER ON -to HDMI_TX_RD[7]
 set_instance_assignment -name PARTITION_HIERARCHY root_partition -to | -section_id Top

--- a/ossc.sdc
+++ b/ossc.sdc
@@ -53,9 +53,10 @@ foreach_in_collection c [get_clocks "pclk_1x pclk_*_source"] {
     set_input_delay -clock $c -max $TVP_dmax $critinputs -add_delay
 }
 
-# output delay constraints
+# output delay constraints as documented in the IT6613 datasheet
+# -- increased IT_Tsu from 1.0 to 1.5 due to #52
 set IT_Tsu 1.5
-set IT_Th -0.3
+set IT_Th -0.5
 set critoutputs_hdmi [get_ports {HDMI_TX_RD* HDMI_TX_GD* HDMI_TX_BD* HDMI_TX_DE HDMI_TX_HS HDMI_TX_VS}]
 foreach_in_collection c [get_clocks pclk_*_out] {
     set_output_delay -clock $c -min $IT_Th $critoutputs_hdmi -add


### PR DESCRIPTION
From the Cyclone IV device handbook:

> When you use the VREF pin as a regular input or output, you can expect
> a reduced performance of toggle rate and tCO because of higher pin
> capacitance.

Previously, we had set all HDMI_TX pins to fast output, but doing so
produces some worrying timing violations which were masked over by
relaxation of the SDC constraints. With fast output enabled, actually
fixing the timing constraints would require substantial RTL
optimization.

Instead, by only setting fast output on the VREF pins, I'm able to avoid
the glitching that would occur without any fast output pins when
displaying high clock rate line3x output, while also allowing fitter
enough flexibility to avoid timing violations.

In addition, this commit restores the previously relaxed HDMI_TX timing
constraints to those documented in the IT6613 datasheet.