### PR TITLE
Add an option to set the HDMI aspect ratio flag

### DIFF
--- a/software/sys_controller/av_controller.c
+++ b/software/sys_controller/av_controller.c
@@ -216,12 +216,13 @@ inline void TX_enable(tx_mode_t mode)
     EnableVideoOutput(cm.hdmitx_pclk_level ? PCLK_HIGH : PCLK_MEDIUM, COLOR_RGB444, (mode == TX_HDMI_YCBCR444) ? COLOR_YUV444 : COLOR_RGB444, (mode != TX_DVI));
 
     if (mode != TX_DVI) {
-        HDMITX_SetAVIInfoFrame(vmode_out.vic, (mode == TX_HDMI_RGB) ? F_MODE_RGB444 : F_MODE_YUV444, 0, 0, tc.hdmi_itc, vm_conf.hdmitx_pixr_ifr);
+        HDMITX_SetAVIInfoFrame(vmode_out.vic, (mode == TX_HDMI_RGB) ? F_MODE_RGB444 : F_MODE_YUV444, tc.hdmi_ar, 0, tc.hdmi_itc, vm_conf.hdmitx_pixr_ifr);
         if (tc.hdmi_vrr)
             HDMITX_SetVRRInfoFrame(tc.hdmi_vrr);
         if (tc.hdmi_hdr)
             HDMITX_SetHDRInfoFrame(tc.hdmi_hdr ? 3 : 0);
         cm.cc.hdmi_itc = tc.hdmi_itc;
+        cm.cc.hdmi_ar = tc.hdmi_ar;
         cm.cc.hdmi_hdr = tc.hdmi_hdr;
         cm.cc.hdmi_vrr = tc.hdmi_vrr;
     }
@@ -743,7 +744,7 @@ void program_mode()
         cm.hdmitx_pclk_level = hdmitx_pclk_level;
         TX_enable(cm.cc.tx_mode);
     } else if (cm.cc.tx_mode!=TX_DVI) {
-        HDMITX_SetAVIInfoFrame(vmode_out.vic, (cm.cc.tx_mode == TX_HDMI_RGB) ? F_MODE_RGB444 : F_MODE_YUV444, 0, 0, cm.cc.hdmi_itc, vm_conf.hdmitx_pixr_ifr);
+        HDMITX_SetAVIInfoFrame(vmode_out.vic, (cm.cc.tx_mode == TX_HDMI_RGB) ? F_MODE_RGB444 : F_MODE_YUV444, cm.cc.hdmi_ar, 0, cm.cc.hdmi_itc, vm_conf.hdmitx_pixr_ifr);
 #ifdef MANUAL_CTS
         SetupAudio(cm.cc.tx_mode);
 #endif
@@ -1257,11 +1258,12 @@ int main()
             cm.clkcnt = 0; //TODO: proper invalidate
         }
         if (tc.tx_mode != TX_DVI) {
-            if (tc.hdmi_itc != cm.cc.hdmi_itc) {
+            if (tc.hdmi_itc != cm.cc.hdmi_itc || tc.hdmi_ar != cm.cc.hdmi_ar) {
                 //EnableAVIInfoFrame(FALSE, NULL);
-                printf("setting ITC to %d\n", tc.hdmi_itc);
-                HDMITX_SetAVIInfoFrame(vmode_out.vic, (tc.tx_mode == TX_HDMI_RGB) ? F_MODE_RGB444 : F_MODE_YUV444, 0, 0, tc.hdmi_itc, vm_conf.hdmitx_pixr_ifr);
+                printf("setting ITC to %d\nsetting Aspect-Ratio to %d\n", tc.hdmi_itc, tc.hdmi_ar);
+                HDMITX_SetAVIInfoFrame(vmode_out.vic, (tc.tx_mode == TX_HDMI_RGB) ? F_MODE_RGB444 : F_MODE_YUV444, tc.hdmi_ar, 0, tc.hdmi_itc, vm_conf.hdmitx_pixr_ifr);
                 cm.cc.hdmi_itc = tc.hdmi_itc;
+                cm.cc.hdmi_ar = tc.hdmi_ar;
             }
             if (tc.hdmi_vrr != cm.cc.hdmi_vrr) {
                 printf("setting VRR flag to %d\n", tc.hdmi_vrr);

--- a/software/sys_controller/ic_drivers/it6613/HDMI_TX.c
+++ b/software/sys_controller/ic_drivers/it6613/HDMI_TX.c
@@ -78,12 +78,12 @@ bool HDMITX_HPD(void){
 }
 
 
-void HDMITX_SetAVIInfoFrame(alt_u8 VIC, alt_u8 OutputColorMode, bool b16x9, bool ITU709, bool ITC, alt_u8 pixelrep)
+void HDMITX_SetAVIInfoFrame(alt_u8 VIC, alt_u8 OutputColorMode, alt_u8 AspectRatio, bool ITU709, bool ITC, alt_u8 pixelrep)
 {
     AVI_InfoFrame AviInfo;
 
-    OS_PRINTF("HDMITX_SetAVIInfoFrame: VIC=%d, ColorMode=%d, Aspect-Ratio=%s, ITU709=%s, ITC=%s, pixelrep=%u\n",
-        VIC, OutputColorMode, b16x9?"16:9":"4:3", ITU709?"Yes":"No", ITC?"Yes":"No", pixelrep);
+    OS_PRINTF("HDMITX_SetAVIInfoFrame: VIC=%d, ColorMode=%d, Aspect-Ratio=%d, ITU709=%s, ITC=%s, pixelrep=%u\n",
+        VIC, OutputColorMode, AspectRatio, ITU709?"Yes":"No", ITC?"Yes":"No", pixelrep);
 
     AviInfo.pktbyte.AVI_HB[0] = AVI_INFOFRAME_TYPE|0x80 ;
     AviInfo.pktbyte.AVI_HB[1] = AVI_INFOFRAME_VER ;
@@ -108,7 +108,7 @@ void HDMITX_SetAVIInfoFrame(alt_u8 VIC, alt_u8 OutputColorMode, bool b16x9, bool
     //AviInfo.pktbyte.AVI_DB[0] = (0<<5)|(1<<4) ;
     AviInfo.pktbyte.AVI_DB[0] |= 2; // indicate "no overscan"
     AviInfo.pktbyte.AVI_DB[1] = 8 ;
-    //AviInfo.pktbyte.AVI_DB[1] |= (!b16x9)?(1<<4):(2<<4) ; // 4:3 or 16:9
+    AviInfo.pktbyte.AVI_DB[1] |= (AspectRatio & 3)<<4 ; // 0: aspect ratio not specified, 1: indicate 4:3, 2: indicate 16:9
     AviInfo.pktbyte.AVI_DB[1] |= (!ITU709)?(1<<6):(2<<6) ; // ITU709 or ITU601
     AviInfo.pktbyte.AVI_DB[2] = ((1<<3) | (ITC<<7)) ; // indicate "full-range RGB", setup ITC bit
     AviInfo.pktbyte.AVI_DB[3] = VIC ;

--- a/software/sys_controller/ic_drivers/it6613/HDMI_TX.h
+++ b/software/sys_controller/ic_drivers/it6613/HDMI_TX.h
@@ -12,7 +12,7 @@ bool HDMITX_ChipVerify(void);
 bool HDMITX_HPD(void);
 void HDMITX_ChangeVideoTiming(int VIC);
 void HDMITX_ChangeVideoTimingAndColor(int VIC, COLOR_TYPE Color);
-void HDMITX_SetAVIInfoFrame(alt_u8 VIC, alt_u8 OutputColorMode, bool b16x9, bool ITU709, bool ITC, alt_u8 pixelrep);
+void HDMITX_SetAVIInfoFrame(alt_u8 VIC, alt_u8 OutputColorMode, alt_u8 AspectRatio, bool ITU709, bool ITC, alt_u8 pixelrep);
 
 void HDMITX_DisableVideoOutput(void);
 void HDMITX_EnableVideoOutput(void);

--- a/software/sys_controller/inc/avconfig.h
+++ b/software/sys_controller/inc/avconfig.h
@@ -152,6 +152,7 @@ typedef struct {
     /* TX / extra settings */
     alt_u8 tx_mode;
     alt_u8 hdmi_itc;
+    alt_u8 hdmi_ar;
     alt_u8 hdmi_hdr;
     alt_u8 hdmi_vrr;
     alt_u8 full_tx_setup;

--- a/software/sys_controller/src/menu.c
+++ b/software/sys_controller/src/menu.c
@@ -75,6 +75,7 @@ static const char* const pm_480p_desc[] = { LNG("Passthru","ﾊﾟｽｽﾙｰ")
 static const char* const pm_1080i_desc[] = { LNG("Passthru","ﾊﾟｽｽﾙｰ"), "Line2x (bob)" };
 static const char* const ar_256col_desc[] = { "Pseudo 4:3 DAR", "1:1 PAR" };
 static const char* const tx_mode_desc[] = { "HDMI (RGB)", "HDMI (YCbCr444)", "DVI" };
+static const char* const hdmi_ar_desc[] = { "Not set", "4:3", "16:9" };
 static const char* const sl_mode_desc[] = { LNG("Off","ｵﾌ"), LNG("Auto","ｵｰﾄ"), LNG("On","ｵﾝ") };
 static const char* const sl_method_desc[] = { LNG("Multiplication","Multiplication"), LNG("Subtraction","Subtraction") };
 static const char* const sl_type_desc[] = { LNG("Horizontal","ﾖｺ"), LNG("Vertical","ﾀﾃ"), "Horiz. + Vert.", "Custom" };
@@ -213,6 +214,7 @@ MENU(menu_lm, P99_PROTECT({ \
 MENU(menu_output, P99_PROTECT({ \
     { LNG("TX mode","TXﾓｰﾄﾞ"),                  OPT_AVCONFIG_SELECTION, { .sel = { &tc.tx_mode,         OPT_WRAP, SETTING_ITEM(tx_mode_desc) } } },
     { "HDMI ITC",                              OPT_AVCONFIG_SELECTION, { .sel = { &tc.hdmi_itc,        OPT_WRAP, SETTING_ITEM(off_on_desc) } } },
+    { "HDMI Aspect flag",                      OPT_AVCONFIG_SELECTION, { .sel = { &tc.hdmi_ar,         OPT_WRAP, SETTING_ITEM(hdmi_ar_desc) } } },
     { "HDMI HDR flag",                         OPT_AVCONFIG_SELECTION, { .sel = { &tc.hdmi_hdr,        OPT_WRAP, SETTING_ITEM(off_on_desc) } } },
     { "HDMI VRR flag",                         OPT_AVCONFIG_SELECTION, { .sel = { &tc.hdmi_vrr,        OPT_WRAP, SETTING_ITEM(off_on_desc) } } },
     { "480p/576p pbox",                        OPT_AVCONFIG_SELECTION, { .sel = { &tc.o480p_pbox,       OPT_WRAP, SETTING_ITEM(off_on_desc) } } },


### PR DESCRIPTION
The flag hints the TV which aspect ratio it should use. This might help if the TV doesn't have an aspect ratio setting in game mode, like mine.

Closes #123 

https://github.com/user-attachments/assets/5cdd437f-574f-4559-ba26-378ad92db04b

